### PR TITLE
Validators should not return the value

### DIFF
--- a/flump/validators.py
+++ b/flump/validators.py
@@ -13,5 +13,3 @@ class Immutable(Validator):
     def __call__(self, value):
         if request.method == 'PATCH':
             raise ValidationError("Can't update immutable fields.")
-
-        return value

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -18,8 +18,9 @@ class TestImmutable:
 
     def test_patch_does_not_allow_name_to_be_updated(self, flask_client):
         create_response = create_user(flask_client)
+        _id = create_response.json['data']['id']
         response = patch_user(
-            flask_client, create_response.json['data']['id'],
+            flask_client, _id,
             etag=create_response.headers['Etag']
         )
         assert response.status_code == 422
@@ -32,4 +33,23 @@ class TestImmutable:
                 }
             },
             'message': 'JSON does not match expected schema'
+        }
+
+    def test_patch_does_not_enforce_name_being_present(self, flask_client):
+        create_response = create_user(flask_client)
+        _id = create_response.json['data']['id']
+        response = patch_user(
+            flask_client, _id,
+            etag=create_response.headers['Etag'],
+            data={'data': {'type': 'user', 'id': _id,
+                           'attributes': {'age': 99}}}
+        )
+        assert response.status_code == 200
+        assert response.json == {
+            'data': {
+                'attributes': {'age': 99, 'name': 'Carl'},
+                'id': '1',
+                'type': 'user'
+            },
+            'links': {'self': 'http://localhost/tester/user/1'}
         }


### PR DESCRIPTION
If the value is returned as `False` the validation fails.
