### PR TITLE
Refactor FlumpBlueprint initialisation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,8 +108,8 @@ To hook this into Flask you should first create a FlumpBlueprint.
 
     blueprint = FlumpBlueprint(
         'flump', __name__,
-        flump_views=[UserView(UserSchema, 'user', '/user/')]
     )
+    blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 `FlumpBlueprint` acts like a normal Flask Blueprint, so you can register `before_request`, `after_request` & `teardown_request` handlers as usual.  For example with SQLAlchemy we either want to ``commit`` or ``rollback`` any changes
 which have been made, depending on whether there has been an exception:

--- a/docs/examples/immutable-field.py
+++ b/docs/examples/immutable-field.py
@@ -53,10 +53,8 @@ class UserView(FlumpView):
 
 
 # Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
-blueprint = FlumpBlueprint(
-    'flump-example', __name__,
-    flump_views=[UserView(UserSchema, 'user', '/user/')]
-)
+blueprint = FlumpBlueprint('flump-example', __name__)
+blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 # Create our app and register our Blueprint
 app = Flask(__name__)

--- a/docs/examples/limited-http-methods.py
+++ b/docs/examples/limited-http-methods.py
@@ -49,10 +49,8 @@ class UserView(GetMany, GetSingle, Post, BaseFlumpView):
 
 
 # Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
-blueprint = FlumpBlueprint(
-    'flump-example', __name__,
-    flump_views=[UserView(UserSchema, 'user', '/user/')]
-)
+blueprint = FlumpBlueprint('flump-example', __name__)
+blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 # Create our app and register our Blueprint
 app = Flask(__name__)

--- a/docs/examples/sqlalchemy-auth.py
+++ b/docs/examples/sqlalchemy-auth.py
@@ -89,10 +89,8 @@ class UserView(FlumpView):
 
 
 # Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
-blueprint = FlumpBlueprint(
-    'flump-example', __name__,
-    flump_views=[UserView(UserSchema, 'user', '/user/')]
-)
+blueprint = FlumpBlueprint('flump-example', __name__)
+blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 
 # Define some request teardown, this is necessary to either commit, or rollback

--- a/docs/examples/sqlalchemy-basic.py
+++ b/docs/examples/sqlalchemy-basic.py
@@ -67,8 +67,8 @@ class UserView(FlumpView):
 # Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
 blueprint = FlumpBlueprint(
     'flump-example', __name__,
-    flump_views=[UserView(UserSchema, 'user', '/user/')]
 )
+blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 
 # Define some request teardown, this is necessary to either commit, or rollback

--- a/flump/__init__.py
+++ b/flump/__init__.py
@@ -35,14 +35,9 @@ class FlumpBlueprint(Blueprint):
     request JSON body.
 
     Adds the 'application/vnd.api+json' Content-Type header to all responses.
-
-    :param flump_views: A list of :class:`.view.FlumpView`
     """
-    def __init__(self, *args, flump_views=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        for view in (flump_views or []):
-            self.register_flump_view(view)
 
         register_error_handlers(self)
 
@@ -80,6 +75,16 @@ class FlumpBlueprint(Blueprint):
         self.add_url_rule('{}<entity_id>'.format(flump_view.endpoint),
                           view_func=view_func,
                           methods=('GET', 'PATCH', 'DELETE'))
+
+    def register_flump_views(self, flump_views):
+        """
+        Registers the various URL rules for each of the the given `flump_views`
+        on the Blueprint.
+
+        :param flump_views: List of :class:`.view.FlumpView` to register URLs for.
+        """
+        for flump_view in flump_views:
+            self.register_flump_view(flump_view)
 
 
 class FlumpSchema(Schema):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -73,16 +73,15 @@ class FlumpTestResponse(Response):
 @pytest.yield_fixture
 def app(view_and_schema):
     view_class, schema, _ = view_and_schema
-    flump_view = view_class(schema, 'user', '/user/')
+    blueprint = FlumpBlueprint('flump', __name__)
+    blueprint.register_flump_view(view_class(schema, 'user', '/user/'))
 
     app = Flask(__name__)
     app.response_class = FlumpTestResponse
     app.config['SERVER_NAME'] = 'localhost'
     app.config['SERVER_PROTOCOL'] = 'http'
-    app.register_blueprint(
-        FlumpBlueprint('flump', __name__, flump_views=[flump_view]),
-        url_prefix='/tester'
-    )
+
+    app.register_blueprint(blueprint, url_prefix='/tester')
 
     ctx = app.app_context()
     ctx.push()

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -5,10 +5,8 @@ from flump import FlumpSchema, FlumpView, FlumpBlueprint
 
 
 def test_flump_blueprint():
-    blueprint = FlumpBlueprint(
-        'test_flump', __name__,
-        flump_views=[FlumpView(None, 'blah', '/endpoint/')]
-    )
+    blueprint = FlumpBlueprint('test_flump', __name__)
+    blueprint.register_flump_view(FlumpView(None, 'blah', '/endpoint/'))
 
     assert blueprint.name == 'test_flump'
 


### PR DESCRIPTION
Remove support for passing a list of FlumpViews when creating a
FlumpBlueprint, this was leading to using Flump in a way inconsistent
with Flask design patterns. Instead add a convenience function to
allow registering a list of FlumpViews in one go.
