### PR TITLE
Refactor FlumpView API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ target/
 
 # pyenv local version file.
 .python-version
+
+# Emacs dir locals.
+.dir-locals.el

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,11 @@
 Flump is a database agnostic api builder which depends on `Flask`_ and
 `Marshmallow`_.
 
-Flump tries to be as flexible as possible, giving no strong opinions/implementations
-for many common API features, such as; pagination, filtering, ordering, authentication etc... Instead Flump provides easily mixed in classes which also provide a common interface for extending itself to your needs.
+Flump tries to be as flexible as possible, giving no strong
+opinions/implementations for many common API features, such as; pagination,
+filtering, ordering, authentication etc... Instead Flump provides easily mixed
+in classes which also provide a common interface for extending itself to your
+needs.
 
 Marshmallow is used to provide the Schemas against which data is
 validated and returned.
@@ -11,20 +14,33 @@ validated and returned.
 Getting Started
 ----------------
 
+Registering The Blueprint
+===============
+
+All the endpoints of a flump API live on a ``FlumpBlueprint``. This acts much
+like a normal ``flask.Blueprint``, but provides some flump specific
+functionality.
+
+.. code-block:: python
+
+    blueprint = FlumpBlueprint('flump', __name__)
+
+
 The Schema
 ============
 
-You must define schemas describing your entities. These schemas should
-inherit from ``marshmallow.Schema``.
+You must define schemas describing your entities. These schemas should inherit
+from ``marshmallow.Schema``.
 
-All entities used in Flump must have a field called `etag`, this should be a field
-which auto updates when modified, and is used for concurrency control. For more information see :ref:`etags-design`.
+All entities used in Flump must have a field called `etag`, this should be a
+field which auto updates when modified, and is used for concurrency control. For
+more information see :ref:`etags-design`.
 
 When creating an entity they should also be provided with a unique identifier in
 a field called `id`. For more information see :ref:`ids-design`.
 
-For example when using Flask-SqlAlchemy ORM models you might define
-something like:
+For example when using Flask-SqlAlchemy ORM models you might define something
+like:
 
 .. code-block:: python
 
@@ -68,11 +84,17 @@ methods:
 
 * ``create_entity``, which should create an entity and persist it in your chosen data store, then return the entity.
 
+The View should also define ``RESOURCE_NAME`` and ``SCHEMA`` properties.
+
 .. code-block:: python
 
     from flump import FlumpView
 
+    @blueprint.flump_view('/user/')
     class UserView(FlumpView):
+        RESOURCE_NAME = 'user'
+        SCHEMA = UserSchema
+
         def get_many_entities(self):
             return User.query.all()
 
@@ -98,20 +120,12 @@ methods:
             db.session.flush()
             return model
 
-
-The Blueprint
+Registering The Blueprint
 ===============
 
-To hook this into Flask you should first create a FlumpBlueprint.
-
-.. code-block:: python
-
-    blueprint = FlumpBlueprint(
-        'flump', __name__,
-    )
-    blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
-
-`FlumpBlueprint` acts like a normal Flask Blueprint, so you can register `before_request`, `after_request` & `teardown_request` handlers as usual.  For example with SQLAlchemy we either want to ``commit`` or ``rollback`` any changes
+`FlumpBlueprint` acts like a normal Flask Blueprint, so you can register
+`before_request`, `after_request` & `teardown_request` handlers as usual. For
+example with SQLAlchemy we either want to ``commit`` or ``rollback`` any changes
 which have been made, depending on whether there has been an exception:
 
 .. code-block:: python

--- a/docs/examples/immutable-field.py
+++ b/docs/examples/immutable-field.py
@@ -14,6 +14,10 @@ INSTANCES = []
 User = namedtuple('User', ('id', 'etag', 'name', 'age'))
 
 
+# Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
+blueprint = FlumpBlueprint('flump-example', __name__)
+
+
 # Our Schema, we make the name field `Immutable`, so we cannot update it
 # with a PATCH request.
 class UserSchema(Schema):
@@ -22,7 +26,11 @@ class UserSchema(Schema):
 
 
 # Our FlumpView, with the necessary methods implemented.
+@blueprint.flump_view('/user/')
 class UserView(FlumpView):
+    SCHEMA = UserSchema
+    RESOURCE_NAME = 'user'
+
     def get_entity(self, entity_id):
         try:
             _id = int(entity_id)
@@ -52,9 +60,6 @@ class UserView(FlumpView):
         return entity._replace(**data)
 
 
-# Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
-blueprint = FlumpBlueprint('flump-example', __name__)
-blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 # Create our app and register our Blueprint
 app = Flask(__name__)

--- a/docs/examples/limited-http-methods.py
+++ b/docs/examples/limited-http-methods.py
@@ -17,6 +17,10 @@ INSTANCES = []
 User = namedtuple('User', ('id', 'etag', 'name'))
 
 
+# Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
+blueprint = FlumpBlueprint('flump-example', __name__)
+
+
 class UserSchema(Schema):
     name = fields.Str(required=True)
 
@@ -24,7 +28,11 @@ class UserSchema(Schema):
 # Our FlumpView, as we are only supporing GET and POST, we don't need to
 # implement the `delete_entity` method. We also only inherit from the
 # BaseFlumpView class, and mixin the `Get`, `GetMany` and `Post` methods.
+@blueprint.flump_view('/user/')
 class UserView(GetMany, GetSingle, Post, BaseFlumpView):
+    SCHEMA = UserSchema
+    RESOURCE_NAME = 'user'
+
     def get_entity(self, entity_id):
         try:
             _id = int(entity_id)
@@ -45,10 +53,6 @@ class UserView(GetMany, GetSingle, Post, BaseFlumpView):
         INSTANCES.append(entity)
         return entity
 
-
-# Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
-blueprint = FlumpBlueprint('flump-example', __name__)
-blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 # Create our app and register our Blueprint
 app = Flask(__name__)

--- a/docs/examples/sqlalchemy-auth.py
+++ b/docs/examples/sqlalchemy-auth.py
@@ -56,7 +56,11 @@ class UserSchema(Schema):
 
 
 # Define our FlumpView class with the necessary methods overridden.
+@blueprint.flump_view('/user/')
 class UserView(FlumpView):
+    SCHEMA = UserSchema
+    RESOURCE_NAME = 'user'
+
     def get_many_entities(self):
         return User.query.all()
 
@@ -86,11 +90,6 @@ class UserView(FlumpView):
         # can therefore return the ID.
         db.session.flush()
         return model
-
-
-# Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
-blueprint = FlumpBlueprint('flump-example', __name__)
-blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 
 # Define some request teardown, this is necessary to either commit, or rollback

--- a/docs/examples/sqlalchemy-basic.py
+++ b/docs/examples/sqlalchemy-basic.py
@@ -13,6 +13,12 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/basic-test.db'
 db = SQLAlchemy(app)
 
 
+# Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
+blueprint = FlumpBlueprint(
+    'flump-example', __name__,
+)
+
+
 # Define our User model
 class User(db.Model):
     __tablename__ = 'user'
@@ -32,7 +38,11 @@ class UserSchema(Schema):
 
 
 # Define our FlumpView class with the necessary methods overridden.
+@blueprint.flump_view('/user/')
 class UserView(FlumpView):
+    SCHEMA = UserSchema
+    RESOURCE_NAME = 'user'
+
     def get_many_entities(self):
         return User.query.all()
 
@@ -62,13 +72,6 @@ class UserView(FlumpView):
         # can therefore return the ID.
         db.session.flush()
         return model
-
-
-# Instantiate our FlumpBlueprint ready for hooking up to our Flask app.
-blueprint = FlumpBlueprint(
-    'flump-example', __name__,
-)
-blueprint.register_flump_view(UserView(UserSchema, 'user', '/user/'))
 
 
 # Define some request teardown, this is necessary to either commit, or rollback

--- a/flump/base_view.py
+++ b/flump/base_view.py
@@ -12,20 +12,11 @@ class BaseFlumpView:
     A base view from which all views provided to `FlumpBlueprint` must
     inherit.
 
-    View classes which inherit from this must provide `get_entity` and
-    `delete_entity` methods.
-
-    :param resource_schema: The schema describing the resource. Should be
-                            an instance of :class:`marshmallow.Schema`
-    :param resource_name:   The name of the resource type the API will be
-                            used for.
-    :param endpoint:        The URL endpoint the API should live at.
+    Classes which inherit from this must provide `get_entity` and
+    `delete_entity` methods. They should also provide provide `RESOURCE_NAME` &
+    `SCHEMA` attributes that specify the name of the resource, and the schema
+    to use for serialization/desieralization
     """
-
-    def __init__(self, resource_schema, resource_name, endpoint):
-        self.resource_schema = resource_schema
-        self.resource_name = resource_name
-        self.endpoint = endpoint
 
     def get(self, entity_id=None, **kwargs):
         """
@@ -61,19 +52,19 @@ class BaseFlumpView:
     @property
     def data_schema(self):
         """
-        Returns a Schema describing the main jsonapi format for the
-        current `resource_schema`.
+        A Schema describing the main jsonapi format for `SCHEMA`.
         """
-        return make_data_schema(self.resource_schema,
-                                self._get_sparse_fieldset())
+        return make_data_schema(self.SCHEMA, self._get_sparse_fieldset())
 
     @property
     def response_schema(self):
         """
         A schema describing the format of a response according to jsonapi.
         """
-        return make_response_schema(self.resource_schema,
-                                    only=self._get_sparse_fieldset())
+        return make_response_schema(
+            self.SCHEMA,
+            only=self._get_sparse_fieldset()
+        )
 
     def get_total_entities(self, **kwargs):
         """
@@ -109,7 +100,7 @@ class BaseFlumpView:
         Returns a list of fields which have been requested to be returned.
         """
         requested_fields = request.args.get(
-            'fields[{}]'.format(self.resource_name)
+            'fields[{}]'.format(self.RESOURCE_NAME)
         )
         if requested_fields:
             requested_fields = set(requested_fields.split(','))

--- a/flump/methods/get_many.py
+++ b/flump/methods/get_many.py
@@ -7,7 +7,7 @@ class GetMany:
 
     @property
     def _many_response_schema(self):
-        return make_response_schema(self.resource_schema, many=True,
+        return make_response_schema(self.SCHEMA, many=True,
                                     only=self._get_sparse_fieldset())
 
     def _make_get_many_response(self, entity_data, **kwargs):
@@ -29,7 +29,7 @@ class GetMany:
                           entities to be returned.
         """
         entities = [
-            EntityData(i.id, self.resource_name, i)
+            EntityData(i.id, self.RESOURCE_NAME, i)
             for i in self.get_many_entities(**kwargs)
         ]
         data = self._make_get_many_response(entities, **kwargs)

--- a/flump/methods/get_single.py
+++ b/flump/methods/get_single.py
@@ -28,7 +28,7 @@ class GetSingle:
         if self._etag_matches(entity):
             return '', 304
 
-        entity_data = EntityData(entity.id, self.resource_name, entity)
+        entity_data = EntityData(entity.id, self.RESOURCE_NAME, entity)
         response_data, _ = self.response_schema(strict=True).dump(
             ResponseData(entity_data, {'self': request.url})
         )

--- a/flump/methods/patch.py
+++ b/flump/methods/patch.py
@@ -15,9 +15,9 @@ class Patch:
         """
         fields = request.json['data']['attributes'].keys()
         return make_entity_schema(
-            self.resource_schema, self.resource_name,
+            self.SCHEMA, self.RESOURCE_NAME,
             make_data_schema(
-                self.resource_schema, id_required=True,
+                self.SCHEMA, id_required=True,
                 only=fields, partial=True
             )
         )

--- a/flump/methods/post.py
+++ b/flump/methods/post.py
@@ -14,8 +14,8 @@ class Post:
         A schema describing the format of POST request for jsonapi. Provides
         automatic error checking for the data format.
         """
-        return make_entity_schema(self.resource_schema, self.resource_name,
-                                  make_data_schema(self.resource_schema))
+        return make_entity_schema(self.SCHEMA, self.RESOURCE_NAME,
+                                  make_data_schema(self.SCHEMA))
 
     @property
     def post_data(self):
@@ -58,7 +58,7 @@ class Post:
             attributes=self.create_entity(entity_data.attributes)
         )
 
-        url = url_for('.{}'.format(self.resource_name), _external=True,
+        url = url_for('.{}'.format(self.RESOURCE_NAME), _external=True,
                       entity_id=entity_data.attributes.id, _method='GET',
                       **kwargs)
         schema = self.response_schema(strict=True)

--- a/flump/pagination.py
+++ b/flump/pagination.py
@@ -42,7 +42,7 @@ class PageSizePagination:
         args = self.get_pagination_args()
         total_entities = self.get_total_entities(**kwargs)
 
-        parsed_url = urlparse(url_for('.{}'.format(self.resource_name),
+        parsed_url = urlparse(url_for('.{}'.format(self.RESOURCE_NAME),
                                       _external=True, _method='GET', **kwargs))
 
         def make_url(page):

--- a/flump/view.py
+++ b/flump/view.py
@@ -13,7 +13,7 @@ class FlumpView(Patch, Delete, GetMany, GetSingle, Post, BaseFlumpView):
     they can inherit from BaseFlumpView, and mixin whichever HTTP methods they
     prefer.
 
-    View classes which inherit from this must provide the following methods:
+    Classes which inherit from this must provide the following methods:
 
     * ``get_entity``, which retrieves a singular entity given an ``entity_id``.
 
@@ -23,9 +23,9 @@ class FlumpView(Patch, Delete, GetMany, GetSingle, Post, BaseFlumpView):
 
     * ``get_total_entities``,  which should return a count of the total number of entities.
 
-    :param resource_schema: The schema describing the resource. Should be
-                            an instance of :class:`flump.FlumpSchema`
-    :param resource_name:   The name of the resource type the API will be
-                            used for.
-    :param endpoint:        The URL endpoint the API should live at.
+    Classes which inherit from this must provide or set the following properties:
+
+    * ``SCHEMA`` The schema describing the resource. Should be an instance of
+      :class:`flump.FlumpSchema`
+    * ``RESOURCE_NAME`` The name of the resource type the API will be used for.
     """

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,6 +17,12 @@ def view_and_schema():
     instances = []
 
     class UserFlumpView(FlumpView):
+        RESOURCE_NAME = 'user'
+
+        class SCHEMA(Schema):
+            name = fields.Str(required=True)
+            age = fields.Integer(required=True)
+
         def get_entity(self, entity_id):
             nonlocal instances
             try:
@@ -49,11 +55,7 @@ def view_and_schema():
         def update_entity(self, existing_entity, data):
             return existing_entity._replace(**data)
 
-    class UserSchema(Schema):
-        name = fields.Str(required=True)
-        age = fields.Integer(required=True)
-
-    return UserFlumpView, UserSchema, instances
+    return UserFlumpView, UserFlumpView.SCHEMA, instances
 
 
 class FlumpTestResponse(Response):
@@ -74,12 +76,14 @@ class FlumpTestResponse(Response):
 def app(view_and_schema):
     view_class, schema, _ = view_and_schema
     blueprint = FlumpBlueprint('flump', __name__)
-    blueprint.register_flump_view(view_class(schema, 'user', '/user/'))
+    blueprint.register_flump_view(view_class, '/user/')
 
     app = Flask(__name__)
     app.response_class = FlumpTestResponse
     app.config['SERVER_NAME'] = 'localhost'
     app.config['SERVER_PROTOCOL'] = 'http'
+    app.config['DEBUG'] = True
+    app.config['TESTING'] = True
 
     app.register_blueprint(blueprint, url_prefix='/tester')
 

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -3,14 +3,32 @@ from flask import Flask
 from flump import FlumpView, FlumpBlueprint
 
 
+class ViewForTest(FlumpView):
+    RESOURCE_NAME = 'blah'
+    SCHEMA = None
+
 def test_flump_blueprint():
     blueprint = FlumpBlueprint('test_flump', __name__)
-    blueprint.register_flump_view(FlumpView(None, 'blah', '/endpoint/'))
+    blueprint.register_flump_view(ViewForTest, '/endpoint/')
 
     assert blueprint.name == 'test_flump'
 
     app = Flask(__name__)
 
+    app.register_blueprint(blueprint)
+
+    # Assert that 3 routes have been defined.
+    assert len(app.url_map._rules_by_endpoint['test_flump.blah']) == 3
+
+
+def test_flump_view_decorator():
+    blueprint = FlumpBlueprint('test_flump', __name__)
+
+    @blueprint.flump_view('/endpoint/')
+    class View(ViewForTest):
+        pass
+
+    app = Flask(__name__)
     app.register_blueprint(blueprint)
 
     # Assert that 3 routes have been defined.

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -14,6 +14,8 @@ class TestImmutable:
         class NotUpdateableSchema(schema):
             name = fields.Str(required=True, validate=(Immutable(),))
 
+        view.SCHEMA = NotUpdateableSchema
+
         return view, NotUpdateableSchema, instances
 
     def test_patch_does_not_allow_name_to_be_updated(self, flask_client):

--- a/test/test_view.py
+++ b/test/test_view.py
@@ -1,7 +1,6 @@
 def test_flump_view_initialised_correctly(view_and_schema):
     view_class, schema, _ = view_and_schema
 
-    view = view_class(schema, 'blah', '/endpoint/')
-    assert view.resource_schema == schema
-    assert view.resource_name == 'blah'
-    assert view.endpoint == '/endpoint/'
+    view = view_class()
+    assert view.SCHEMA == schema
+    assert view.RESOURCE_NAME == 'user'


### PR DESCRIPTION
The existing view API specifies the schema, resource name & URL as
parameters to the constructor. This is pretty good when you've got a
bunch of simple API endpoints that work pretty much the same way - they
can all share the same class, and just have these parameters changed
appropriately.

However, when you're creating a less homogeneous API and need to specify
a class specific to an endpoint this becomes a bit clumsy.  You have to
define a class, then at a later point instantiate it with some
parameters and pass it to the flump blueprint.

I figured it would be a bit nicer if the whole process could be done at
once - you could define your custom class, provide the resource name &
schema as part of this class, and use a decorator to register it on the
blueprint.  So, I've done that.

It also seemed a bit messy to have 2 APIs for creating views - the
existing API and this new one, so I've removed support for the older
one.  It's not much more verbose, and keeps it nice and clear how to go
about implementing the advanced stuff.