### PR TITLE
Make Immutable printable (Fixes #14)

### DIFF
--- a/flump/validators.py
+++ b/flump/validators.py
@@ -10,6 +10,10 @@ class Immutable(Validator):
     request.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.error = None
+
     def __call__(self, value):
         if request.method == 'PATCH':
             raise ValidationError("Can't update immutable fields.")

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -53,3 +53,8 @@ class TestImmutable:
             },
             'links': {'self': 'http://localhost/tester/user/1'}
         }
+
+    def test_can_print_immutable(self):
+        # A wierd test to have, but I was getting exceptions messing about
+        # with things from the repl.
+        print(Immutable())


### PR DESCRIPTION
The base marshmallow Validator class provides a `__repr__` function,
that expects an attribute `error`.  We didn't have this, so printing out
a field with Immutable validator was crashing.  Not something that'd
happen very often, but can definitely happen at a repl.  For now I'm
just adding this attribute as None by default.