### PR TITLE
Don't try and parse JSON in default logger

### DIFF
--- a/flump/__init__.py
+++ b/flump/__init__.py
@@ -18,7 +18,7 @@ from flask import Blueprint, request
 from .base_view import _FlumpMethodView
 from .error_handlers import register_error_handlers
 from .view import FlumpView
-from .web_utils import get_json, MIMETYPE
+from .web_utils import MIMETYPE
 
 __all__ = ['FlumpView', 'FlumpBlueprint']
 __version__ = "0.7.2"
@@ -47,12 +47,10 @@ class FlumpBlueprint(Blueprint):
 
             debug_string = (
                 "%s request made for resource type %s with kwargs: %s "
-                "and json: %s"
+                "and data: %s"
             )
-
             logger.debug(
-                debug_string, request.method, request.view_args,
-                get_json() if request.method in ('PATCH', 'POST') else ''
+                debug_string, request.method, request.view_args, request.data
             )
 
         @self.after_request


### PR DESCRIPTION
If we attach endpoints other than FlumpViews to the blueprint,
they may not accept json, causing an error when logging.