### PR TITLE
Automatically append trailing slask for specific entity URLs

### DIFF
--- a/flump/__init__.py
+++ b/flump/__init__.py
@@ -72,9 +72,11 @@ class FlumpBlueprint(Blueprint):
 
         self.add_url_rule(url, methods=('GET',), view_func=view_func)
         self.add_url_rule(url, view_func=view_func, methods=('POST',))
-        self.add_url_rule('{}<entity_id>'.format(url),
-                          view_func=view_func,
-                          methods=('GET', 'PATCH', 'DELETE'))
+        self.add_url_rule(
+            '{}{}<entity_id>'.format(url, '' if url[-1] == '/' else '/'),
+            view_func=view_func,
+            methods=('GET', 'PATCH', 'DELETE')
+        )
 
     def flump_view(self, url):
         """

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -7,6 +7,7 @@ class ViewForTest(FlumpView):
     RESOURCE_NAME = 'blah'
     SCHEMA = None
 
+
 def test_flump_blueprint():
     blueprint = FlumpBlueprint('test_flump', __name__)
     blueprint.register_flump_view(ViewForTest, '/endpoint/')
@@ -17,8 +18,8 @@ def test_flump_blueprint():
 
     app.register_blueprint(blueprint)
 
-    # Assert that 3 routes have been defined.
-    assert len(app.url_map._rules_by_endpoint['test_flump.blah']) == 3
+    rules = [i.rule for i in app.url_map._rules_by_endpoint['test_flump.blah']]
+    assert rules == ['/endpoint/', '/endpoint/', '/endpoint/<entity_id>']
 
 
 def test_flump_view_decorator():
@@ -32,4 +33,19 @@ def test_flump_view_decorator():
     app.register_blueprint(blueprint)
 
     # Assert that 3 routes have been defined.
-    assert len(app.url_map._rules_by_endpoint['test_flump.blah']) == 3
+    rules = [i.rule for i in app.url_map._rules_by_endpoint['test_flump.blah']]
+    assert rules == ['/endpoint/', '/endpoint/', '/endpoint/<entity_id>']
+
+
+def test_adds_trailing_slash_to_id_specific_route_if_left_off():
+    blueprint = FlumpBlueprint('test_flump', __name__)
+    blueprint.register_flump_view(ViewForTest, '/endpoint')
+
+    assert blueprint.name == 'test_flump'
+
+    app = Flask(__name__)
+
+    app.register_blueprint(blueprint)
+
+    rules = [i.rule for i in app.url_map._rules_by_endpoint['test_flump.blah']]
+    assert rules == ['/endpoint', '/endpoint', '/endpoint/<entity_id>']


### PR DESCRIPTION
If the URL wasn't specified to having a trailing slash, then the
entity specifc URL would look like `url<entity_id>`, now it looks like
`url/<entity_id>`