### PR TITLE
Keep non-pagination query string params in links.

### DIFF
--- a/flump/pagination.py
+++ b/flump/pagination.py
@@ -44,11 +44,17 @@ class PageSizePagination:
 
         parsed_url = urlparse(url_for('.{}'.format(self.RESOURCE_NAME),
                                       _external=True, _method='GET', **kwargs))
+        other_query_params = [
+            (k, v) for (k, v) in request.args.items()
+            if k not in ('page[number]', 'page[size]')
+        ]
 
         def make_url(page):
             if not total_entities:
                 return None
-            params = (('page[number]', page), ('page[size]', args.size))
+            params = other_query_params + [
+                ('page[number]', page), ('page[size]', args.size)
+            ]
             return parsed_url._replace(query=urlencode(params)).geturl()
 
         num_pages = int(ceil(total_entities / float(args.size)))

--- a/test/methods/test_get_many.py
+++ b/test/methods/test_get_many.py
@@ -123,7 +123,7 @@ class TestGetManyWithPagination:
 
         response = flask_client.get(
             url_for('flump.user', _method='GET'),
-            query_string='page[number]=2&page[size]=3'
+            query_string='other_param=test&page[number]=2&page[size]=3'
         )
 
         base_url = 'http://localhost/tester/user'
@@ -146,10 +146,10 @@ class TestGetManyWithPagination:
                 }
             ],
             'links': {
-                'self': base_url + '?page[number]=2&page[size]=3',
-                'first': base_url + '?page%5Bnumber%5D=1&page%5Bsize%5D=3',
-                'last': base_url + '?page%5Bnumber%5D=4&page%5Bsize%5D=3',
-                'prev': base_url + '?page%5Bnumber%5D=1&page%5Bsize%5D=3',
-                'next': base_url + '?page%5Bnumber%5D=3&page%5Bsize%5D=3'
+                'self': base_url + '?other_param=test&page[number]=2&page[size]=3',
+                'first': base_url + '?other_param=test&page%5Bnumber%5D=1&page%5Bsize%5D=3',
+                'last': base_url + '?other_param=test&page%5Bnumber%5D=4&page%5Bsize%5D=3',
+                'prev': base_url + '?other_param=test&page%5Bnumber%5D=1&page%5Bsize%5D=3',
+                'next': base_url + '?other_param=test&page%5Bnumber%5D=3&page%5Bsize%5D=3'
             }
         }


### PR DESCRIPTION
This commit updates our pagination link generation code to keep all the
non-pagination related query string parameters in the URL.  This should
allow client applications to use the links to navigate through several
pages of filtered data.

Fixes #32