### PR TITLE
Allow flump to run on python 2.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,6 @@ machine:
 
 ## Customize dependencies..
 dependencies:
-  pre:
-    - pip install -r dev-requirements.txt
-
-test:
   override:
-    - py.test test
+    - pip install tox tox-pyenv
+    - pyenv local 2.7.10 3.5.0

--- a/flump/__init__.py
+++ b/flump/__init__.py
@@ -36,7 +36,7 @@ class FlumpBlueprint(Blueprint):
     Adds the 'application/vnd.api+json' Content-Type header to all responses.
     """
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(FlumpBlueprint, self).__init__(*args, **kwargs)
 
         register_error_handlers(self)
 

--- a/flump/base_view.py
+++ b/flump/base_view.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import NotImplemented as WerkzeugNotImplemented
 from .schemas import make_data_schema, make_response_schema
 
 
-class BaseFlumpView:
+class BaseFlumpView(object):
     """
     A base view from which all views provided to `FlumpBlueprint` must
     inherit.

--- a/flump/exceptions.py
+++ b/flump/exceptions.py
@@ -2,7 +2,7 @@ from werkzeug.exceptions import UnprocessableEntity
 
 
 class FlumpUnprocessableEntity(UnprocessableEntity):
-    def __init__(self, *args, errors=None, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, errors=None, *args, **kwargs):
+        super(FlumpUnprocessableEntity, self).__init__(*args, **kwargs)
 
         self.errors = errors

--- a/flump/pagination.py
+++ b/flump/pagination.py
@@ -1,6 +1,10 @@
 from collections import namedtuple
 from math import ceil
-from urllib.parse import urlencode, urlparse
+try:
+    from urllib.parse import urlencode, urlparse
+except ImportError:
+    from urllib import urlencode
+    from urlparse import urlparse
 
 from flask import request
 
@@ -10,7 +14,7 @@ from .web_utils import url_for
 PaginationArgs = namedtuple('PaginationArgs', ('page', 'size'))
 
 
-class PageSizePagination:
+class PageSizePagination(object):
     """
     Mixin class which provides methods for Number/Size based pagination.
     """
@@ -74,7 +78,9 @@ class PageSizePagination:
 
         Also adds the `max_results` and `page` args to the meta.
         """
-        response = super()._make_get_many_response(entity_data, **kwargs)
+        response = super(PageSizePagination, self)._make_get_many_response(
+            entity_data, **kwargs
+        )
         response = response._replace(links=self.get_pagination_links(**kwargs))
         pagination_args = self.get_pagination_args()
         meta = response.meta

--- a/flump/validators.py
+++ b/flump/validators.py
@@ -11,7 +11,7 @@ class Immutable(Validator):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(Immutable, self).__init__(*args, **kwargs)
         self.error = None
 
     def __call__(self, value):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,7 +24,6 @@ def view_and_schema():
             age = fields.Integer(required=True)
 
         def get_entity(self, entity_id):
-            nonlocal instances
             try:
                 _id = int(entity_id)
             except ValueError:
@@ -34,19 +33,15 @@ def view_and_schema():
                 return instances[_id - 1]
 
         def get_total_entities(self, **kwargs):
-            nonlocal instances
             return len(instances)
 
         def get_many_entities(self, **kwargs):
-            nonlocal instances
             return instances
 
         def delete_entity(self, entity):
-            nonlocal instances
             instances.pop(int(entity.id) - 1)
 
         def create_entity(self, data):
-            nonlocal instances
             entity = User(str(len(instances) + 1), uuid.uuid4(),
                           data['name'], data['age'])
             instances.append(entity)

--- a/test/methods/test_get_many.py
+++ b/test/methods/test_get_many.py
@@ -56,7 +56,6 @@ class TestGetManyWithPagination:
             DEFAULT_PAGE_SIZE = 2
 
             def get_many_entities(self, **kwargs):
-                nonlocal instances
                 pagination_args = self.get_pagination_args()
                 chunks = [
                     instances[i:i + pagination_args.size]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist=py27,py35
+[testenv]
+deps= -rdev-requirements.txt
+commands=py.test test


### PR DESCRIPTION
A handful of tweaks to the code to allow it to work on python 2:

- Pass arguments to super.
- Inherit from object.
- Import urllib.parse functions from elsewhere.

Also updates circle to run the tests on 2.7 & 3.5