### PR TITLE
Add nicer error message for invalid page size/number

### DIFF
--- a/flump/pagination.py
+++ b/flump/pagination.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from math import ceil
+from werkzeug.exceptions import BadRequest
 
 from flask import request
 
@@ -58,6 +59,11 @@ class PageSizePagination(BasePagination):
         """
         page = int(request.args.get('page[number]') or 1)
         size = int(request.args.get('page[size]') or self.DEFAULT_PAGE_SIZE)
+
+        if page < 1 or size < 1:
+            raise BadRequest(
+                "Both page[number] and page[size] must be at least 1"
+            )
 
         return PaginationArgs(max(page, 1), min(size, self.MAX_PAGE_SIZE))
 

--- a/test/methods/test_get_many.py
+++ b/test/methods/test_get_many.py
@@ -159,3 +159,23 @@ class TestGetManyWithPagination:
                 'next': base_url + '?other_param=test&page%5Bnumber%5D=3&page%5Bsize%5D=3'
             }
         }
+
+    def test_invalid_page_number(self, flask_client):
+        response = flask_client.get(
+            url_for('flump.user', _method='GET'),
+            query_string='other_param=test&page[number]=0&page[size]=1'
+        )
+        assert response.status_code == 400
+        assert response.json == {
+            'message': 'Both page[number] and page[size] must be at least 1'
+        }
+
+    def test_invalid_page_size(self, flask_client):
+        response = flask_client.get(
+            url_for('flump.user', _method='GET'),
+            query_string='other_param=test&page[number]=1&page[size]=0'
+        )
+        assert response.status_code == 400
+        assert response.json == {
+            'message': 'Both page[number] and page[size] must be at least 1'
+        }


### PR DESCRIPTION
Why do we need this change?
----

We currently 500 on invalid page size/number, we can catch
this and return a nice error message

What effects does this change have?
----

Check the page size/number and return an error if they
are invalid.